### PR TITLE
Add loop counter logic and AnimatableImageView delegate

### DIFF
--- a/Source/AnimatableImageView.swift
+++ b/Source/AnimatableImageView.swift
@@ -1,18 +1,42 @@
 import UIKit
 
+/// A protocol for the AnimatavleImageView delegate
+public protocol AnimatableImageViewDelegate: class {
+  /// optional delegate method that it is called when an AnimatableImageView animation did stop
+  func animatableImageViewAnimationDidStop(animatableImageView: AnimatableImageView)
+}
+
+public extension AnimatableImageViewDelegate {
+  /// forces method to be optional
+  func animatableImageViewAnimationDidStop(animatableImageView: AnimatableImageView) { }
+}
+
 /// A subclass of `UIImageView` that can be animated using an image name string or raw data.
 public class AnimatableImageView: UIImageView {
+  /// animatable image view delegate instance
+  public weak var delegate: AnimatableImageViewDelegate?
+
   /// An `Animator` instance that holds the frames of a specific image in memory.
   var animator: Animator?
+
   /// A display link that keeps calling the `updateFrame` method on every screen refresh.
   lazy var displayLink: CADisplayLink = CADisplayLink(target: self, selector: Selector("updateFrame"))
+
+  /// Current loaded data
+  public private(set) var loadedData: NSData?
 
   /// The size of the frame cache.
   public var framePreloadCount = 50
 
+  /// The required number of times the GIF animation is to cycle though the image sequence before stopping. The default is __0__ that means repeating the animation indefinitely. __-1__ means using loop count setting extracted from the GIF data.
+  public var maxLoopCount = 0
+
+  /// Specifies the number of times the animation has been looped.
+  public private(set) var currentLoopCount = 0
+
   /// Specifies whether the GIF frames should be pre-scaled to save memory. Default is **true**.
   public var needsPrescaling = true
-  
+
   /// A computed property that returns whether the image view is animating.
   public var isAnimatingGIF: Bool {
     return !displayLink.paused
@@ -22,12 +46,13 @@ public class AnimatableImageView: UIImageView {
   public var frameCount: Int {
     return animator?.frameCount ?? 0
   }
-  
+
   /// Prepares the frames using a GIF image file name, without starting the animation.
   /// The file name should include the `.gif` extension.
   ///
   /// - parameter imageName: The name of the GIF file. The method looks for the file in the app bundle.
   public func prepareForAnimation(imageNamed imageName: String) {
+    currentLoopCount = 0
     let imagePath = NSBundle.mainBundle().bundleURL.URLByAppendingPathComponent(imageName)
     prepareForAnimation <^> NSData(contentsOfURL: imagePath)
   }
@@ -36,6 +61,7 @@ public class AnimatableImageView: UIImageView {
   ///
   /// - parameter data: GIF image data.
   public func prepareForAnimation(imageData data: NSData) {
+    loadedData = data
     image = UIImage(data: data)
     animator = Animator(data: data, size: frame.size, contentMode: contentMode, framePreloadCount: framePreloadCount)
     animator?.needsPrescaling = needsPrescaling
@@ -62,6 +88,7 @@ public class AnimatableImageView: UIImageView {
   /// Updates the `image` property of the image view if necessary. This method should not be called manually.
   override public func displayLayer(layer: CALayer) {
     image = animator?.currentFrame
+    stopAnimatingIfNeeded()
   }
 
   /// Starts the image view animation.
@@ -75,11 +102,38 @@ public class AnimatableImageView: UIImageView {
   public func stopAnimatingGIF() {
     displayLink.paused = true
   }
-  
+
   /// Reset the image view values
   public func prepareForReuse() {
     stopAnimatingGIF()
     animator = nil
+  }
+
+  /// Stops the animation in accordance with the loop count settings.
+  func stopAnimatingIfNeeded() {
+    guard let animator = animator where animator.currentAnimationPosition == animator.frameCount - 1 else {
+      return
+    }
+
+    currentLoopCount += 1
+    if shouldStopLooping() {
+      currentLoopCount = 0
+      stopAnimatingGIF()
+
+      NSOperationQueue.mainQueue().addOperationWithBlock { [weak self] in
+        guard let strongSelf = self else {
+          return
+        }
+
+        strongSelf.delegate?.animatableImageViewAnimationDidStop(strongSelf)
+      }
+    }
+  }
+
+  /// Specifies whether all of the required animation iterations have been finished.
+  /// - returns: true if the animation should stop looping, false otherwise.
+  func shouldStopLooping() -> Bool {
+    return maxLoopCount > 0 && maxLoopCount == currentLoopCoun
   }
 
   /// Update the current frame with the displayLink duration

--- a/Source/AnimatableImageView.swift
+++ b/Source/AnimatableImageView.swift
@@ -20,7 +20,7 @@ public class AnimatableImageView: UIImageView {
   var animator: Animator?
 
   /// A display link that keeps calling the `updateFrame` method on every screen refresh.
-  lazy var displayLink: CADisplayLink = CADisplayLink(target: self, selector: Selector("updateFrame"))
+  lazy var displayLink: CADisplayLink = CADisplayLink(target: self, selector: #selector(updateFrame))
 
   /// Current loaded data
   public private(set) var loadedData: NSData?

--- a/Source/Animator.swift
+++ b/Source/Animator.swift
@@ -37,6 +37,17 @@ class Animator {
     return imageSource.isAnimatedGIF
   }
 
+  /// The index of the currently displayed GIF frame.
+  var currentAnimationPosition: Int {
+    guard animatedFrames.count != frameCount else {
+        return currentFrameIndex
+    }
+
+    // Compute the animation position using currentPreloadIndex and current cache count properties.
+    let animationPosition = currentPreloadIndex - animatedFrames.count
+    return (animationPosition < 0) ? (animationPosition + frameCount) : animationPosition
+  }
+
   /// Initializes an animator instance from raw GIF image data and an `Animatable` delegate.
   ///
   /// - parameter data: The raw GIF image data.

--- a/Source/Animator.swift
+++ b/Source/Animator.swift
@@ -114,12 +114,12 @@ class Animator {
 
     timeSinceLastFrameChange -= frameDuration
     let lastFrameIndex = currentFrameIndex
-    currentFrameIndex = ++currentFrameIndex % animatedFrames.count
+    currentFrameIndex = (currentFrameIndex + 1) % animatedFrames.count
     
     // Loads the next needed frame for progressive loading
     if animatedFrames.count < frameCount {
       animatedFrames[lastFrameIndex] = prepareFrame(currentPreloadIndex)
-      currentPreloadIndex = ++currentPreloadIndex % frameCount
+      currentPreloadIndex = (currentPreloadIndex + 1) % frameCount
     }
     
     return true

--- a/Source/ImageSourceHelpers.swift
+++ b/Source/ImageSourceHelpers.swift
@@ -41,9 +41,11 @@ func durationFromGIFProperties(properties: GIFProperties) -> Double? {
 /// Calculates frame duration based on both clamped and unclamped times.
 ///
 /// - returns: A frame duration.
-func duration(unclampedDelayTime: Double)(delayTime: Double) -> Double {
-  let delayArray = [unclampedDelayTime, delayTime]
-  return delayArray.filter(isPositive).first ?? defaultDuration
+func duration(unclampedDelayTime: Double) -> Double -> Double {
+  return {(delayTime: Double) -> Double in
+    let delayArray = [unclampedDelayTime, delayTime]
+      return delayArray.filter(isPositive).first ?? defaultDuration
+  }
 }
 
 /// Checks if a `Double` value is positive.


### PR DESCRIPTION
The main loop logic was extracted from
kaishin#42, a open PR from @storix
that was still not merged at the time this commit was created

Add loop counter logic and optional delegate method which is called when
an animation stops

Add a public getter for the current loop count and a setter/getter for
the max number of loops. If max number of loops is set to 0 it loops
forever

Add loadedData which hold the data that is currently loaded in the
AnimatableImageView. It has a private setter and a public getter